### PR TITLE
Complete User Story 1

### DIFF
--- a/app/controllers/doctors_controller.rb
+++ b/app/controllers/doctors_controller.rb
@@ -1,0 +1,5 @@
+class DoctorsController < ApplicationController
+  def show
+    @doctor = Doctor.find(params[:id])
+  end
+end

--- a/app/models/hospital.rb
+++ b/app/models/hospital.rb
@@ -1,5 +1,5 @@
 class Hospital < ApplicationRecord
-  validates_presence_of :address, :city, :state, :zip
+  validates_presence_of :name, :address, :city, :state, :zip
 
   has_many :doctors
 end

--- a/app/views/doctors/show.html.erb
+++ b/app/views/doctors/show.html.erb
@@ -1,0 +1,11 @@
+<h1>Doctor: <%= @doctor.name %></h1>
+<p>Specialty: <%= @doctor.specialty %></p>
+<p>Education: <%= @doctor.education %></p>
+<p>Place of Employment: <%= @doctor.hospital.name %></p>
+
+<h1>Patients:</h1>
+<% @doctor.patients.each do |patient| %>
+  <ul>
+    <li>Name: <%= patient.name %></li>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  get "/doctors/:id", to: "doctors#show"
 end

--- a/db/migrate/20200608172103_add_name_to_hospitals.rb
+++ b/db/migrate/20200608172103_add_name_to_hospitals.rb
@@ -1,0 +1,5 @@
+class AddNameToHospitals < ActiveRecord::Migration[5.1]
+  def change
+    add_column :hospitals, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200608162852) do
+ActiveRecord::Schema.define(version: 20200608172103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20200608162852) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
   end
 
   create_table "patients", force: :cascade do |t|

--- a/spec/features/doctors/show_spec.rb
+++ b/spec/features/doctors/show_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe "Doctor Show Page", type: :feature do
+  describe "when I visit /doctors/:id" do
+    before(:each) do
+      @anschutz = Hospital.create!(name: "CU Anschutz Medical Center", address: "13001 East 17th Place", city: "Aurora", state: "CO", zip: 80045)
+      @unmh = Hospital.create!(name: "UNM Hospital", address: "2211 Lomas Blvd. NE", city: "Albuquerque", state: "NM", zip: 87106)
+      @doctor_1 = @anschutz.doctors.create!(name: "T. Fernandes", specialty: "Oncology", education: "Harvard")
+      @doctor_2 = @unmh.doctors.create!(name: "S. Santos", specialty: "Pediatrics", education: "Cornell")
+      @patient_a = @doctor_1.patients.create!(name: "A", age: 20)
+      @patient_b = @doctor_1.patients.create!(name: "B", age: 57)
+      @patient_c = @doctor_2.patients.create!(name: "C", age: 12)
+
+      visit "/doctors/#{@doctor_1.id}"
+    end
+
+    it "I see that doctor's information" do
+      expect(page).to have_content("Doctor: T. Fernandes")
+      expect(page).to have_content("Specialty: Oncology")
+      expect(page).to have_content("Education: Harvard")
+      expect(page).to have_content ("Place of Employment: CU Anschutz Medical Center")
+      expect(page).to_not have_content("Doctor: S. Santos")
+    end
+
+    it "I see a list of the doctor's patients" do
+      expect(page).to have_content("Name: #{@patient_a.name}")
+      expect(page).to have_content("Name: #{@patient_b.name}")
+      expect(page).to_not have_content("Name: #{@patient_c.name}")
+    end
+  end
+end
+
+# User Story 1, Doctors Show Page
+# 'As a visitor
+# When I visit a doctor's show page
+# I see all of that doctor's information including:
+#  - name
+#  - specialty
+#  - university where they got their doctorate
+
+# And I see the name of the hospital where this doctor works
+
+# And I see the names of all of the patients this doctor has

--- a/spec/models/hospital_spec.rb
+++ b/spec/models/hospital_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Hospital, type: :model do
   describe "validations" do
+    it {should validate_presence_of :name}
     it {should validate_presence_of :address}
     it {should validate_presence_of :city}
     it {should validate_presence_of :state}


### PR DESCRIPTION
For this process process, I had to troubleshoot a few things. First, I was missing the name column for hospitals, so I had to add the migration for that. In my view, patients were being displayed twice, and that let me to remove the repeated association between doctors and patients, as I had already linked them together when creating the patient objects. Finally, I had the change the setup of my last test to include the full text of a patient's name, as it would error out by finding text that matched a patient belonging to a different doctor.